### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ jobs:
   publish:
     name: "Build and publish release"
     runs-on: ubuntu-latest
-    environment: trusted-publisher
-    # Granting permissions for OIDC token exchange (Trusted Publishers)
+    environment: pypi
+    # Granting permissions for OIDC token exchange
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
The publication was incorrectly performed by "trusted-publishers", though pypi was not expecting such environment (valid token, but no corresponding publisher (Publisher with matching claims was not found)). Corrected the environment to match pypi's expectation.