### PR TITLE
Feat/web3 documentation

### DIFF
--- a/examples/rizenet_testnet/src/client.py
+++ b/examples/rizenet_testnet/src/client.py
@@ -9,7 +9,8 @@ from rizemind.configuration.toml_config import TomlConfig
 from rizemind.strategies.contribution.shapley.decentralized.shapley_value_client import (
     DecentralShapleyValueClient,
 )
-from rizemind.web3.config import WEB3_CONFIG_STATE_KEY, Web3Config
+from rizemind.web3 import Web3Config
+from rizemind.web3.config import WEB3_CONFIG_STATE_KEY
 
 from .task import Net, get_weights, load_data, set_weights, test, train
 

--- a/examples/rizenet_testnet/src/server.py
+++ b/examples/rizenet_testnet/src/server.py
@@ -16,7 +16,7 @@ from rizemind.strategies.contribution.shapley.shapley_value_strategy import (
     TrainerSetAggregate,
 )
 from rizemind.swarm.config import SwarmConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 from .task import Net, get_weights
 

--- a/examples/torch_dyn_diff_privacy_shapley/src/client.py
+++ b/examples/torch_dyn_diff_privacy_shapley/src/client.py
@@ -20,7 +20,8 @@ from rizemind.strategies.contribution.shapley.decentralized.shapley_value_client
     DecentralShapleyValueClient,
 )
 from rizemind.swarm.swarm import Swarm
-from rizemind.web3.config import WEB3_CONFIG_STATE_KEY, Web3Config
+from rizemind.web3 import Web3Config
+from rizemind.web3.config import WEB3_CONFIG_STATE_KEY
 from torch.utils.data import DataLoader
 
 from .task import Net, get_weights, load_data, set_weights, test, train

--- a/examples/torch_dyn_diff_privacy_shapley/src/server.py
+++ b/examples/torch_dyn_diff_privacy_shapley/src/server.py
@@ -16,7 +16,7 @@ from rizemind.strategies.contribution.shapley.decentralized.shapley_value_strate
 )
 from rizemind.strategies.contribution.shapley.shapley_value_strategy import Coalition
 from rizemind.swarm.config import SwarmConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 from .task import Net, get_weights
 

--- a/examples/torch_shapley/src/client.py
+++ b/examples/torch_shapley/src/client.py
@@ -9,7 +9,8 @@ from rizemind.configuration.toml_config import TomlConfig
 from rizemind.strategies.contribution.shapley.decentralized.shapley_value_client import (
     DecentralShapleyValueClient,
 )
-from rizemind.web3.config import WEB3_CONFIG_STATE_KEY, Web3Config
+from rizemind.web3 import Web3Config
+from rizemind.web3.config import WEB3_CONFIG_STATE_KEY
 
 from .task import Net, get_weights, load_data, set_weights, test, train
 

--- a/examples/torch_shapley/src/server.py
+++ b/examples/torch_shapley/src/server.py
@@ -16,7 +16,7 @@ from rizemind.strategies.contribution.shapley.shapley_value_strategy import (
     TrainerSetAggregate,
 )
 from rizemind.swarm.config import SwarmConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 from .task import Net, get_weights
 

--- a/sphinx/source/references/index.rst
+++ b/sphinx/source/references/index.rst
@@ -9,3 +9,4 @@ References
    authentication/index
    configuration/index
    logging/index
+   web3/index

--- a/sphinx/source/references/web3/config.rst
+++ b/sphinx/source/references/web3/config.rst
@@ -1,0 +1,6 @@
+Web3 Config
+=========================
+
+.. automodule:: rizemind.web3.config
+    :members:
+    :show-inheritance:

--- a/sphinx/source/references/web3/index.rst
+++ b/sphinx/source/references/web3/index.rst
@@ -1,0 +1,11 @@
+Web3 Module
+==============
+
+.. automodule:: rizemind.web3
+   :no-members:
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   config

--- a/src/py/rizemind/authentication/notary/model/mod.py
+++ b/src/py/rizemind/authentication/notary/model/mod.py
@@ -27,7 +27,7 @@ from rizemind.configuration.transform import concat
 from rizemind.exception.base_exception import RizemindException
 from rizemind.exception.parse_exception import ParseException
 from rizemind.swarm.config import SwarmConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 
 class MissingConfigNotaryModError(RizemindException):

--- a/src/py/rizemind/cli/swarm/__init__.py
+++ b/src/py/rizemind/cli/swarm/__init__.py
@@ -11,7 +11,7 @@ from rizemind.cli.account.options import AccountNameOption, MnemonicOption
 from rizemind.contracts.swarm.swarm_v1.swarm_v1_factory import SwarmV1FactoryConfig
 from rizemind.swarm.certificate.certificate import Certificate, CompressedCertificate
 from rizemind.swarm.config import SwarmConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 swarm = typer.Typer(help="Federation management commands")
 

--- a/src/py/rizemind/web3/__init__.py
+++ b/src/py/rizemind/web3/__init__.py
@@ -1,0 +1,11 @@
+"""Web3 blockchain connectivity and configuration utilities.
+
+This module provides configuration management and utilities for connecting to
+Web3-compatible blockchain networks. It includes support for HTTP providers,
+Proof-of-Authority middleware injection, and integration with the Flower
+federated learning framework.
+"""
+
+from rizemind.web3.config import Web3Config
+
+__all__ = ["Web3Config"]

--- a/src/py/rizemind/web3/config.py
+++ b/src/py/rizemind/web3/config.py
@@ -3,11 +3,12 @@ from typing import Any
 from flwr.common.context import Context
 from pydantic import Field, HttpUrl, field_validator
 from pydantic_core import Url
+from web3 import HTTPProvider, Web3
+from web3.middleware import ExtraDataToPOAMiddleware
+
 from rizemind.configuration.base_config import BaseConfig
 from rizemind.configuration.transform import unflatten
 from rizemind.web3.chains import RIZENET_TESTNET_CHAINID
-from web3 import HTTPProvider, Web3
-from web3.middleware import ExtraDataToPOAMiddleware
 
 poaChains = [RIZENET_TESTNET_CHAINID]
 
@@ -15,11 +16,36 @@ WEB3_CONFIG_STATE_KEY = "rizemind.web3"
 
 
 class Web3Config(BaseConfig):
+    """Configuration for Web3 blockchain connections.
+
+    Manages Web3 provider configuration including URL validation, middleware
+    injection for Proof-of-Authority chains, and Web3 instance creation.
+
+    Attributes:
+        url: The HTTP provider URL for blockchain connectivity. If None,
+            defaults to RizeNet testnet URL.
+    """
+
     url: HttpUrl | None = Field(..., description="The HTTP provider URL")
 
     @field_validator("url", mode="before")
     @classmethod
     def coerce_url(cls, value: Any) -> Any:
+        """Validates and coerces URL values to HttpUrl format.
+
+        Handles various input types and converts them to the appropriate
+        HttpUrl format for Pydantic validation.
+
+        Args:
+            value: The URL value to validate. Can be None, string, HttpUrl, or Url.
+
+        Returns:
+            The validated HttpUrl object or None.
+
+        Raises:
+            TypeError: If the value type is not supported.
+            ValidationError: If the URL string is invalid (raised by HttpUrl).
+        """
         # Let Pydantic handle None or already-parsed HttpUrl
         if value is None or isinstance(value, HttpUrl | Url):
             return value
@@ -28,12 +54,32 @@ class Web3Config(BaseConfig):
         raise TypeError("url must be a string, HttpUrl, or None")
 
     def get_web3(self, *, web3_factory=Web3) -> Web3:
+        """Creates a configured Web3 instance.
+
+        Initializes a Web3 instance with the configured HTTP provider and
+        automatically injects Proof-of-Authority middleware for supported chains.
+
+        Args:
+            web3_factory: Factory function for creating Web3 instances.
+                Defaults to the standard Web3 constructor.
+
+        Returns:
+            A configured Web3 instance ready for blockchain interaction.
+        """
         w3 = web3_factory(self.web3_provider())
         if w3.eth.chain_id in poaChains:
             w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
         return w3
 
     def web3_provider(self) -> HTTPProvider:
+        """Creates an HTTP provider for Web3 connections.
+
+        Constructs an HTTPProvider using the configured URL or defaults
+        to the RizeNet testnet if no URL is specified.
+
+        Returns:
+            An HTTPProvider instance configured with the appropriate endpoint URL.
+        """
         url = self.url
         if url is None:
             url = "https://testnet.rizenet.io"
@@ -41,6 +87,18 @@ class Web3Config(BaseConfig):
 
     @staticmethod
     def from_context(context: Context) -> "Web3Config | None":
+        """Creates a Web3Config instance from a Flower context.
+
+        Extracts Web3 configuration from the provided Flower context state
+        and constructs a Web3Config instance if the configuration exists.
+
+        Args:
+            context: The Flower context containing configuration state.
+
+        Returns:
+            A Web3Config instance if configuration is found in the context,
+            otherwise None.
+        """
         if WEB3_CONFIG_STATE_KEY in context.state.config_records:
             records: Any = context.state.config_records[WEB3_CONFIG_STATE_KEY]
             return Web3Config(**unflatten(records))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from flwr.common.typing import UserConfig
 from rizemind.authentication.config import AccountConfig
 from rizemind.authentication.signatures.signature import Signature
 from rizemind.contracts.erc.erc5267.typings import EIP712DomainMinimal
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
 

--- a/tests/integration/forge_fixtures.py
+++ b/tests/integration/forge_fixtures.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 from pydantic import HttpUrl
 from rizemind.authentication import AccountConfig
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 
 from .forge_helper import start_anvil
 

--- a/tests/unit/py/rizemind/authentication/notary/model/test_mod.py
+++ b/tests/unit/py/rizemind/authentication/notary/model/test_mod.py
@@ -34,7 +34,7 @@ from rizemind.exception.base_exception import RizemindException
 from rizemind.exception.parse_exception import ParseException
 from rizemind.swarm.config import SWARM_CONFIG_STATE_KEY, SwarmConfig
 from rizemind.swarm.swarm import Swarm
-from rizemind.web3.config import Web3Config
+from rizemind.web3 import Web3Config
 from web3 import Web3
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose Web3Config at rizemind.web3 and add Sphinx docs for the web3 module, updating imports project‑wide.
> 
> - **Web3 module**:
>   - Expose `Web3Config` at package root via `rizemind.web3` (`src/py/rizemind/web3/__init__.py`).
>   - Improve `Web3Config` docs/docstrings in `rizemind/web3/config.py` (clarify URL coercion, POA middleware, context loading).
> - **Refactor imports (examples, src, tests)**:
>   - Replace `from rizemind.web3.config import Web3Config` with `from rizemind.web3 import Web3Config` across clients/servers, CLI, and tests.
>   - Keep `WEB3_CONFIG_STATE_KEY` imports from `rizemind.web3.config` where needed.
> - **Docs**:
>   - Add Sphinx reference pages for `web3` module and `web3.config`; include `web3/index` in `references/index.rst`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 859c5cdda2c73dadc9c4f19bae213f032e7f6944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->